### PR TITLE
Keep Exit button inside the focus mode card

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3377,10 +3377,10 @@ body.focus-mode::after {
 
 body.focus-mode .btn-max-focus {
     background: linear-gradient(135deg, var(--accent-orange), #e17055);
-    position: fixed;
-    top: 20px;
-    right: 20px;
-    z-index: 1002;
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    z-index: 2;
     font-size: 0.85rem;
     padding: 10px 22px;
     box-shadow: 0 2px 12px rgba(0,0,0,0.4);


### PR DESCRIPTION
Changed from position:fixed (floating at screen corner) to position:absolute so it stays in the same spot where the Maximize button was.

https://claude.ai/code/session_011GmrrDukwFmdmUjwvaEtQ2